### PR TITLE
Move pre-initialization of weapon slots to world loading instead.

### DIFF
--- a/ZScript/MC/Base.txt
+++ b/ZScript/MC/Base.txt
@@ -10,19 +10,23 @@ Class MCHandlerStatic : StaticEventHandler
 	override void OnRegister()
 	{
 		SetOrder(4999);
-		WeaponList = new('MCWeaponList');
-		WeaponList.Init();
 		Super.OnRegister();
 	}
 	
 	override void OnUnregister()
 	{
 		InGame = false;
+		Super.OnUnregister();
 	}
 	
 	override void WorldLoaded(WorldEvent e)
 	{
 		Queue.Clear();
+		if (!WeaponList || e.IsSaveGame)
+		{
+			WeaponList = new('MCWeaponList');
+			WeaponList.Init();
+		}
 		InGame = true;
 	}
 	
@@ -111,18 +115,18 @@ Class MCHandler : EventHandler
 		SetOrder(5000); // Plenty of room to go above and below.
 		Super.OnRegister();
 	}
-	
+	/*
 	override void WorldLoaded(WorldEvent e)
 	{
 	}
-	
+	*/
 	override void WorldUnloaded(WorldEvent e)
 	{
 		Monsters.Clear();
 		DeadMonsters.Clear();
 		Missiles.Clear();
 	}
-	
+	/*
 	override void WorldThingSpawned(WorldEvent e)
 	{
 	}
@@ -134,7 +138,7 @@ Class MCHandler : EventHandler
 	override void WorldThingDestroyed(WorldEvent e)
 	{
 	}
-	
+	*/
 	// This is where it all begins.
 	override bool InputProcess(InputEvent ev)
 	{

--- a/ZScript/MC/WeaponSwitch.txt
+++ b/ZScript/MC/WeaponSwitch.txt
@@ -47,11 +47,12 @@ Class MCWeaponList play
 		Unsorted.Clear();
 		for (int i = 0; i < AllActorClasses.Size(); ++i)
 		{
-			// Validate first.
+			// Validate first. If it's not a weapon, skip it.
 			let wep = (Class<Weapon>)(AllActorClasses[i]);
 			if (!wep)	continue;
 			
-			// Skip all bad assignments.
+			// Skip all bad assignments. Weapons need a slot number [0, 9]
+			// and range [0.0, 1.0].
 			let def = GetDefaultByType(wep);
 			if (def.SlotNumber < 0 || def.SlotNumber > 9 || 
 				def.SlotPriority > 1.0 || def.SlotPriority < 0.0)
@@ -60,14 +61,24 @@ Class MCWeaponList play
 			Weapons.Push(wep);
 		}
 		
-		// 5.998...
-		// 5.999...
-		// 4.000...
-		// ...wait WHAT THE FUCK!?
-		// Sadly that's the case here. I don't know why it was designed this way
-		// internally, but it's crazy.
-		// Sort through all weapons based on those schematics. Surprisingly,
-		// this was a little easier than I thought it would be.
+		// Now we have all the weapons, sort through all of them.
+		// Also, for future reference:
+		// Un = Unsorted
+		// We = Sorted Weapon
+		
+		// This array is iterated through like this:
+		// | = Sub-iterated through
+		// - = Not iterated through
+		// ||||||||||
+		// -|||||||||
+		// --||||||||
+		// ---|||||||
+		// ----||||||
+		// -----|||||
+		// ------||||
+		// -------|||
+		// --------||
+		// Where each time, the array is started one step closer to the end.
 		
 		int size = Weapons.Size();
 		for (int i = 0; i < size - 1; i++)
@@ -82,6 +93,7 @@ Class MCWeaponList play
 				// Put slot 0 weapons at the top by faking them to be 10.
 				if (UnSlot == 0)	UnSlot = 10;
 				if (WeSlot == 0)	WeSlot = 10;
+				
 				// First, we need to sort out based on slot. If it's behind,
 				// switch it. This will group them all up together in DESCENDING
 				// order.
@@ -103,7 +115,7 @@ Class MCWeaponList play
 			}
 		}
 		
-		// Debug function for printing all VALID weapons thath ave been picked up
+		// Debug function for printing all VALID weapons that have been picked up
 		// and sorted into the selection array. If a weapon doesn't display,
 		// that means the slot number and/or priority is set wrong.
 		
@@ -345,6 +357,7 @@ extend class MCHandlerStatic
 					// Calls NetworkEvent in Base.txt and assembles the command
 					// to call ChangeWeapons function below, and aborts the 
 					// rest of the input.
+					
 					EventHandler.SendNetworkEvent(String.Format("MC_SelectWeapon:%s", KeyBindsNetEvents[i]));
 					return true;
 				}
@@ -371,7 +384,7 @@ extend class MCHandlerStatic
 			
 		PlayerInfo player = players[pnum];
 
-		if (!player) // Return if the player is null
+		if (!player) // No player.
 			return null;
 
 		Array<String> commandStrings;
@@ -419,6 +432,7 @@ extend class MCHandlerStatic
 		if (!next)	next = ready;
 		if (next && next != ready)	
 			player.PendingWeapon = next;
+		else next = null;
 		
 		return next;
 	}


### PR DESCRIPTION
- According to a commit on GZDoom by Graf, OnRegister is supposed to never be used for anything else but SetOrder.
- https://zdoom.org/Changelog/0422f40d8/files